### PR TITLE
Fix onload issue

### DIFF
--- a/web-extension/site-webscripts/org/alfresco/form/controls/datatable-property.ftl
+++ b/web-extension/site-webscripts/org/alfresco/form/controls/datatable-property.ftl
@@ -37,9 +37,13 @@
 
 
 <script type="text/javascript">//<![CDATA[
-
-window.onload = function(e) { DTP.init("${fieldHtmlId}", "${dtConfig?html}", "${form.mode}", "${field.label?html}"); };
-
+if (window.addEventListener) {
+	window.addEventListener('load', function() { DTP.init("${fieldHtmlId}", "${dtConfig?html}", "${form.mode}", "${field.label?html}"); });
+} else if (window.attachEvent) {
+	window.attachEvent('onload', function() { DTP.init("${fieldHtmlId}", "${dtConfig?html}", "${form.mode}", "${field.label?html}"); });
+} else {
+	window.onload = function(e) { DTP.init("${fieldHtmlId}", "${dtConfig?html}", "${form.mode}", "${field.label?html}"); };
+}
 if (typeof(DTP) == "undefined") { var DTP = {}; }
 
 DTP = {


### PR DESCRIPTION
I ran into an issue with Alfresco 5.1 where some other javascript was also using window.onload, so the datatable was not being rendered.  Using addEventListener avoids this issue.  attachEvent is available for older browsers and onload remains as a last resort
